### PR TITLE
fix indention of resources definition

### DIFF
--- a/cratedb/templates/statefulset.yaml
+++ b/cratedb/templates/statefulset.yaml
@@ -65,8 +65,7 @@ spec:
             - -Chttp.cors.enabled={{ .Values.http.cors.enabled }}
             - -Cpath.data={{ .Values.cratedbConfig.dataPath }}
           {{- if .Values.resources }}
-          resources:
-          {{ toYaml .Values.resources | indent 12 }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
           ports:
             # Port 4300 for inter-node communication.


### PR DESCRIPTION
Current chart indents the first line of the resources definition to far. This PR changes that to create the resources definition in a new line with the correct indention for the first entry.