### PR TITLE
fix bug in service account template

### DIFF
--- a/cratedb/templates/serviceaccount.yaml
+++ b/cratedb/templates/serviceaccount.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cratedb.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
   labels:
     {{- include "cratedb.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Service account template is not honoring the namespace in values file thus changing the namespace in values.yaml causes deployment of statefulset to fail